### PR TITLE
Updated Rivet dependency

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,27 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Copyright (c) 2018 TheTrustees of Indiana University
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Licensed under the BSD 3-Clause License.
 
-   1. Definitions.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+  1.Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+  2.Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+  3.Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/dist/css/rivet-switch.css
+++ b/dist/css/rivet-switch.css
@@ -1,22 +1,34 @@
 /*!
- * rivet-switch - @version 0.1.1-alpha
+ * rivet-switch - @version 0.2.0
  *
- * Copyright (c) 2018, The Trustees of Indiana University
+ * Licensed under the BSD 3-Clause License.
 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
 
- * http://www.apache.org/licenses/LICENSE-2.0
+ *  1.Redistributions of source code must retain the above copyright notice,
+ *  this list of conditions and the following disclaimer.
+ *  2.Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  3.Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*! Rivet - @version v1.0.0 */
+/*! rivet-uits - @version v1.1.0-alpha.2 */
 .rvt-switch {
   -webkit-box-align: center;
       -ms-flex-align: center;

--- a/dist/css/rivet-switch.min.css
+++ b/dist/css/rivet-switch.min.css
@@ -1,19 +1,31 @@
 /*!
- * rivet-switch - @version 0.1.1-alpha
+ * rivet-switch - @version 0.2.0
  *
- * Copyright (c) 2018, The Trustees of Indiana University
+ * Licensed under the BSD 3-Clause License.
 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
 
- * http://www.apache.org/licenses/LICENSE-2.0
+ *  1.Redistributions of source code must retain the above copyright notice,
+ *  this list of conditions and the following disclaimer.
+ *  2.Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  3.Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*! Rivet - @version v1.0.0 */.rvt-switch{-ms-flex-align:center;align-items:center;background:none;background-color:#ddd;border:.125rem solid #ccc;border-radius:.25rem;display:-ms-flexbox;display:flex;font-weight:700;height:2.5rem;line-height:1.1;padding:.25rem;position:relative;-webkit-appearance:none}.rvt-switch:after{background-color:#fff;border-radius:.25rem;content:" ";height:1.75rem;left:.25rem;position:absolute;top:.25rem;transition:transform .2s ease;width:2.25rem}.rvt-switch:focus{box-shadow:0 0 0 .125rem #fff,0 0 0 .25rem #006298;outline:none;transition:box-shadow .2s ease}.rvt-switch[aria-checked=true]{background-color:#006298;border-color:#006298;color:#fff}.rvt-switch[aria-checked=true]:after{transform:translate(2.75rem)}.rvt-switch__off,.rvt-switch__on{border-radius:.25rem;padding:.4rem .5rem;transition:all .2s ease}.rvt-switch[aria-checked=false] .rvt-switch__on,.rvt-switch[aria-checked=true] .rvt-switch__off{visibility:hidden}.rvt-switch--danger[aria-checked=true]{background-color:#df3603;border-color:#df3603}.rvt-switch--success[aria-checked=true]{background-color:#008a28;border-color:#008a28}.rvt-switch--small{height:1.5rem;padding:.125rem}.rvt-switch--small:after{height:1rem;left:.125rem;top:.125rem;width:1.5rem}.rvt-switch--small[aria-checked=true]:after{transform:translate(2.1rem)}.rvt-switch--small .rvt-switch__off,.rvt-switch--small .rvt-switch__on{font-size:.875rem;padding:.125rem .25rem}
+/*! rivet-uits - @version v1.1.0-alpha.2 */.rvt-switch{-ms-flex-align:center;align-items:center;background:none;background-color:#ddd;border:.125rem solid #ccc;border-radius:.25rem;display:-ms-flexbox;display:flex;font-weight:700;height:2.5rem;line-height:1.1;padding:.25rem;position:relative;-webkit-appearance:none}.rvt-switch:after{background-color:#fff;border-radius:.25rem;content:" ";height:1.75rem;left:.25rem;position:absolute;top:.25rem;transition:transform .2s ease;width:2.25rem}.rvt-switch:focus{box-shadow:0 0 0 .125rem #fff,0 0 0 .25rem #006298;outline:none;transition:box-shadow .2s ease}.rvt-switch[aria-checked=true]{background-color:#006298;border-color:#006298;color:#fff}.rvt-switch[aria-checked=true]:after{transform:translate(2.75rem)}.rvt-switch__off,.rvt-switch__on{border-radius:.25rem;padding:.4rem .5rem;transition:all .2s ease}.rvt-switch[aria-checked=false] .rvt-switch__on,.rvt-switch[aria-checked=true] .rvt-switch__off{visibility:hidden}.rvt-switch--danger[aria-checked=true]{background-color:#df3603;border-color:#df3603}.rvt-switch--success[aria-checked=true]{background-color:#008a28;border-color:#008a28}.rvt-switch--small{height:1.5rem;padding:.125rem}.rvt-switch--small:after{height:1rem;left:.125rem;top:.125rem;width:1.5rem}.rvt-switch--small[aria-checked=true]:after{transform:translate(2.1rem)}.rvt-switch--small .rvt-switch__off,.rvt-switch--small .rvt-switch__on{font-size:.875rem;padding:.125rem .25rem}

--- a/dist/js/rivet-switch.js
+++ b/dist/js/rivet-switch.js
@@ -1,19 +1,31 @@
 /*!
- * rivet-switch - @version 0.1.1-alpha
+ * rivet-switch - @version 0.2.0
  *
- * Copyright (c) 2018, The Trustees of Indiana University
+ * Licensed under the BSD 3-Clause License.
 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
 
- * http://www.apache.org/licenses/LICENSE-2.0
+ *  1.Redistributions of source code must retain the above copyright notice,
+ *  this list of conditions and the following disclaimer.
+ *  2.Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  3.Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 (function (root, factory) {

--- a/dist/js/rivet-switch.min.js
+++ b/dist/js/rivet-switch.min.js
@@ -1,19 +1,31 @@
 /*!
- * rivet-switch - @version 0.1.1-alpha
+ * rivet-switch - @version 0.2.0
  *
- * Copyright (c) 2018, The Trustees of Indiana University
+ * Licensed under the BSD 3-Clause License.
 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
 
- * http://www.apache.org/licenses/LICENSE-2.0
+ *  1.Redistributions of source code must retain the above copyright notice,
+ *  this list of conditions and the following disclaimer.
+ *  2.Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  3.Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 !function(t,e){"function"==typeof define&&define.amd?define([],function(){return e(t)}):"object"==typeof exports?module.exports=e(t):t.Switch=e(t)}("undefined"!=typeof global?global:"undefined"!=typeof window?window:this,function(t){"use strict";var n=function(t,e){var n=new CustomEvent(e,{bubbles:!0,detail:{name:function(){return t.getAttribute("data-switch")}}});t.dispatchEvent(n)},i=function(t,e){t.setAttribute("aria-checked","true"),n(t,"switchOn"),e&&"function"==typeof e&&e()},o=function(t,e){t.setAttribute("aria-checked","false"),n(t,"switchOff"),e&&"function"==typeof e&&e()},e=function(t){var e=t.target.closest("[data-switch]");e&&("false"===e.getAttribute("aria-checked")?i(e):o(e))};return{on:i,off:o,init:function(){document.addEventListener("click",e,!1)}}});

--- a/docs/css/rivet-switch.css
+++ b/docs/css/rivet-switch.css
@@ -1,4 +1,4 @@
-/*! Rivet - @version v1.0.0 */
+/*! rivet-uits - @version v1.1.0-alpha.2 */
 .rvt-switch {
   align-items: center;
   background: none;

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>Rivet Switch</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://assets.uits.iu.edu/css/rivet/1.0.0/rivet.min.css">
+  <link rel="stylesheet" href="https://assets.uits.iu.edu/css/rivet/1.1.0-alpha.2/rivet.min.css">
   <link rel="stylesheet" type="text/css" media="screen" href="./css/rivet-switch.css"/>
   <style>
     /* Demo styles */

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,25 +12,34 @@ const runSequence = require('run-sequence');
 const del = require('del');
 const package = require('./package.json');
 
-// Get the current year for copyright in the banner
-const currentYear = new Date().getFullYear();
-
 const banner = `/*!
  * ${package.name} - @version ${package.version}
  *
- * Copyright (c) ${currentYear}, The Trustees of Indiana University
+ * Licensed under the BSD 3-Clause License.
 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
 
- * http://www.apache.org/licenses/LICENSE-2.0
+ *  1.Redistributions of source code must retain the above copyright notice,
+ *  this list of conditions and the following disclaimer.
+ *  2.Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  3.Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 `;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7466,9 +7466,9 @@
       }
     },
     "rivet-uits": {
-      "version": "1.0.0",
-      "resolved": "https://apps.iu.edu/nxs-prd/content/groups/external-npm/rivet-uits/-/rivet-uits-1.0.0.tgz",
-      "integrity": "sha1-AOog/zIJ2nnQUf/6z2THdupoe+o="
+      "version": "1.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/rivet-uits/-/rivet-uits-1.1.0-alpha.2.tgz",
+      "integrity": "sha512-oxL6ncHooOzDYEB53+9aCcpO0+RfU8wAHf44Ga79LCqJwxrlkjDW2O3UkEgSNhmjvTNxBILVYeJdTnDmH5zEng=="
     },
     "run-sequence": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
   "name": "rivet-switch",
-  "version": "0.1.1-alpha",
+  "version": "0.1.1",
   "description": "An accessible switch component for Rivet",
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "https://github.com/indiana-university/rivet-switch"
+  },
+  "bugs": {
+    "url": "https://github.com/indiana-university/rivet-switch/issues",
+    "email": "rivet@iu.edu"
   },
   "main": "dist/js/rivet-switch.js",
   "scripts": {
@@ -12,9 +17,8 @@
     "build": "gulp release"
   },
   "author": "Indiana University",
-  "license": "Apache-2.0",
   "dependencies": {
-    "rivet-uits": "^1.0.0"
+    "rivet-uits": "^1.1.0-alpha.2"
   },
   "devDependencies": {
     "autoprefixer": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivet-switch",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "An accessible switch component for Rivet",
   "license": "BSD-3-Clause",
   "repository": {

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>Rivet Switch</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://assets.uits.iu.edu/css/rivet/1.0.0/rivet.min.css">
+  <link rel="stylesheet" href="https://assets.uits.iu.edu/css/rivet/1.1.0-alpha.2/rivet.min.css">
   <link rel="stylesheet" type="text/css" media="screen" href="./css/rivet-switch.css"/>
   <style>
     /* Demo styles */


### PR DESCRIPTION
I'm getting this PR open to test rivet `1.1.0-alpha.2`. I've updated the dependency, ran it locally, and rebuilt the `dist` folder. Everything seems good. I'll leave this open until we finalize the `1.1.0` release then we can update, merge and do a new release here.